### PR TITLE
In setupSlides don't want to compare each slide with this.current tosee i

### DIFF
--- a/Source/SlideShow.js
+++ b/Source/SlideShow.js
@@ -132,7 +132,7 @@ var SlideShow = this.SlideShow = new Class({
 		this.slides.each(function(slide, index){
 			slide.store('slideshow-index', index).store('slideshow:oldStyles', slide.get('style'));
 			this.storeData(slide);
-			slide.setStyle('display', (this.current || index == this.options.initialSlideIndex) ? '' : 'none');
+			slide.setStyle('display', (slide == this.current || index == this.options.initialSlideIndex) ? '' : 'none');
 		}, this);
 		return this;
 	},


### PR DESCRIPTION
In setupSlides don't want to compare each slide with this.current tosee if display should be set to none or not? Else no slides are hidden (set to display 'none') when you call setup() after add slides (dynamically or whatever). So, display should be set to none if slide != this.current
