### PR TITLE
SlideShow.CSS cleanup and generalized

### DIFF
--- a/Source/SlideShow.CSS.js
+++ b/Source/SlideShow.CSS.js
@@ -20,14 +20,13 @@ provides:
 */
 
 ;(function(){
-
 	function getAxis(direction){
 		return {
 			property: (direction == 'left' || direction == 'right') ? 'x' : 'y',
 			inverted: (direction == 'left' || direction == 'up') ? 1 : -1
 		};
-	}
-
+	};
+	
 	function go(type, axis, data){
 		var transition = {
 			duration: data.duration + 'ms',
@@ -35,31 +34,24 @@ provides:
 			property: 'transform'
 		};
 
-		if (type == 'blind')
-			data.next.setStyle('z-index', 2);
-
-		if (type != 'slide')
-			data.next.translate(axis.property, 100 * axis.inverted);
-
+		if (type == 'blind') data.next.setStyle('z-index', 2);
+		if (type != 'slide') data.next.translate(axis.property, 100 * axis.inverted);
 		setTimeout(function(){
-			if (type != 'slide')
-				data.next.setTransition(transition).translate(axis.property, 0);
-			if (type != 'blind')
-				data.previous.setTransition(transition).translate(axis.property, -(100 * axis.inverted));
-		}, 0);
-
-	}
+			if (type != 'slide') data.next.setTransition(transition).translate(axis.property, 0);
+			if (type != 'blind') data.previous.setTransition(transition).translate(axis.property, -(100 * axis.inverted));
+		}, 100);
+	};
 
 	['left', 'right', 'up', 'down'].each(function(direction){
-
 		var capitalized = direction.capitalize(),
+			pushName = 'push' + capitalized + 'CSS',
 			blindName = 'blind' + capitalized + 'CSS',
 			slideName = 'slide' + capitalized + 'CSS';
-
+			
 		[
-
-			['push' + capitalized + 'CSS', (function(){
+			[pushName, (function(){
 				var axis = getAxis(direction);
+				
 				return function(data){
 					go('push', axis, data);
 				}
@@ -67,6 +59,7 @@ provides:
 
 			[blindName, (function(){
 				var axis = getAxis(direction);
+				
 				return function(data){
 					go('blind', axis, data);
 				}
@@ -74,6 +67,7 @@ provides:
 
 			[slideName, (function(){
 				var axis = getAxis(direction);
+				
 				return function(data){
 					go('slide', axis, data);
 				}
@@ -83,17 +77,18 @@ provides:
 			SlideShow.defineTransition(transition[0], transition[1]);
 		});
 	});
-
 })();
 
-SlideShow.useCSS = function(){
-	['left', 'right', 'up', 'down'].each(function(direction){
-		var capitalized = direction.capitalize(),
-			blindName = 'blind' + capitalized,
-			slideName = 'slide' + capitalized;
-		SlideShow.transitions[blindName] = SlideShow.transitions[blindName + 'CSS'];
-		SlideShow.transitions[slideName] = SlideShow.transitions[blindName + 'CSS'];
-		SlideShow.transitions['push' + capitalized] = SlideShow.transitions['push' + capitalized + 'CSS'];
-	});
-	return this;
-}
+SlideShow.implement({
+	useCSS: function(){
+		// Replace transitions with its CSS postfixed variant
+		this.transitions.each(function(transition, name){
+			var cssTransition = this.transitions[name + 'CSS'];
+			if (cssTransition) {
+				this.transitions[name] = cssTransition;
+			}
+		});
+
+		return this;
+	}
+});


### PR DESCRIPTION
Cleaned SlideShow.CSS class (push transitions are added the same like blind and slide) and the SlideShow.useCSS function is generalized, so all transitions with CSS postfixes are used instead (adding your own CSS transition is as simple as postfixing CSS to the transition).
